### PR TITLE
Fix No Ramdisk found issue. 

### DIFF
--- a/anykernel.sh
+++ b/anykernel.sh
@@ -36,6 +36,7 @@ kernel_version=$(cat /proc/version | awk -F '-' '{print $1}' | awk '{print $3}')
 case $kernel_version in
     5.1*) ksu_supported=true ;;
     6.1*) ksu_supported=true ;;
+    6.6*) ksu_supported=true ;;
     *) ksu_supported=false ;;
 esac
 

--- a/anykernel.sh
+++ b/anykernel.sh
@@ -44,11 +44,11 @@ ui_print " " "  -> ksu_supported: $ksu_supported"
 $ksu_supported || abort "  -> Non-GKI device, abort."
 
 # boot install
-if [ -L "/dev/block/bootdevice/by-name/init_boot_a" -o -L "/dev/block/by-name/init_boot_a" ]; then
-    split_boot # for devices with init_boot ramdisk
-    flash_boot # for devices with init_boot ramdisk
+split_boot
+if [ -f "split_img/ramdisk.cpio" ]; then
+    unpack_ramdisk
+    write_boot
 else
-    dump_boot # use split_boot to skip ramdisk unpack, e.g. for devices with init_boot ramdisk
-    write_boot # use flash_boot to skip ramdisk repack, e.g. for devices with init_boot ramdisk
+    flash_boot
 fi
 ## end boot install


### PR DESCRIPTION
This fixes the issue for Samsung devices, such as Samsung S24 devices, and other devices with init_boot but a single slot.

shell: su -c ls -la /dev/block/bootdevice/by-name/init_boot* 
< lrwxrwxrwx 1 root root 16 1970-12-19 22:58 /dev/block/bootdevice/by-name/init_boot -> /dev/block/sda28 
shell: su -c ls -la /dev/block/bootdevice/by-name/boot* 
< lrwxrwxrwx 1 root root 16 1970-12-19 22:58 /dev/block/bootdevice/by-name/boot -> /dev/block/sda27

Also for devices with Ramdisk in Vendor boot, like the Pixel 6 series.

Support for the 6.6 kernel has been added by @ukriu